### PR TITLE
chore: DBAL compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php": "^7.1 || ^8.0",
     "matthiasnoback/phpunit-test-service-container": "^3.1",
     "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
-    "doctrine/dbal": "^2.4 || ^3.0"
+    "doctrine/dbal": "^2.4 || ^3.0 || ^4.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php": "^7.1 || ^8.0",
     "matthiasnoback/phpunit-test-service-container": "^3.1",
     "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
-    "doctrine/dbal": "^2.4 || ^3.0 || ^4.0"
+    "doctrine/dbal": "^3.10 || ^4.4"
   },
   "autoload": {
     "psr-4": {

--- a/src/Noback/PHPUnitTestServiceContainer/ServiceProvider/DoctrineDbalServiceProvider.php
+++ b/src/Noback/PHPUnitTestServiceContainer/ServiceProvider/DoctrineDbalServiceProvider.php
@@ -10,6 +10,8 @@ use Noback\PHPUnitTestServiceContainer\ServiceContainer;
 use Noback\PHPUnitTestServiceContainer\ServiceProvider;
 use Pimple\Container;
 
+use function class_exists;
+
 final class DoctrineDbalServiceProvider implements ServiceProvider
 {
     private $schema;
@@ -26,16 +28,22 @@ final class DoctrineDbalServiceProvider implements ServiceProvider
             'memory' => true,
         );
 
-        $serviceContainer['doctrine_dbal.event_manager'] = function () {
-            return new EventManager();
-        };
+        if (class_exists(EventManager::class)) {
+            $serviceContainer['doctrine_dbal.event_manager'] = function () {
+                return new EventManager();
+            };
+        }
 
         $serviceContainer['doctrine_dbal.connection'] = function (ServiceContainer $serviceContainer) {
-            return DriverManager::getConnection(
-                $serviceContainer['doctrine_dbal.connection_configuration'],
-                null,
-                $serviceContainer['doctrine_dbal.event_manager']
-            );
+            if (class_exists(EventManager::class)) {
+                return DriverManager::getConnection(
+                    $serviceContainer['doctrine_dbal.connection_configuration'],
+                    null,
+                    $serviceContainer['doctrine_dbal.event_manager']
+                );
+            }
+
+            return DriverManager::getConnection($serviceContainer['doctrine_dbal.connection_configuration']);
         };
 
         $serviceContainer['doctrine_dbal.schema'] = $this->schema;
@@ -54,7 +62,7 @@ final class DoctrineDbalServiceProvider implements ServiceProvider
     private function createSchema(Connection $connection, Schema $schema)
     {
         foreach ($schema->toSql($connection->getDatabasePlatform()) as $sql) {
-            $connection->exec($sql);
+            $connection->executeStatement($sql);
         }
     }
 


### PR DESCRIPTION
Since DBAL 4, we don't have anymore `EventManager`. But it seems it was used for connection and in the connection, it does not need anymore too.

So for compatibiliy following if we have the class `EventManager`, we use it or not.

In addition to this, I change `Connection::exec` by `Connection::executeStatement` because of remove of `exec` in DBAL 3. `executeStatement` is available since `DBAL ≥ 2.13` according to Claude so the replacement should work for all DBAL versions.

At the end, I remove the unmaintained versions of DBAL: see https://www.doctrine-project.org/projects/dbal.html.

Thanks,

Mickaël